### PR TITLE
Add labels to `google_compute_global_address` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_gke_fleet_host_project_id"></a> [gke\_fleet\_host\_project\_id](#input\_gke\_fleet\_host\_project\_id) | The project ID of the GKE Hub host project | `string` | `""` | no |
 | <a name="input_istio_gateway_dns"></a> [istio\_gateway\_dns](#input\_istio\_gateway\_dns) | Map of attributes for the Istio gateway domain names, it is also used to create the managed certificate resource | <pre>map(object({<br>    managed_zone = string<br>    project      = string<br>  }))</pre> | `{}` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | A map of key/value pairs to assign to the resources being created | `map(string)` | `{}` | no |
 | <a name="input_project"></a> [project](#input\_project) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 
 ### Outputs

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@
 resource "google_compute_global_address" "istio_gateway_mci" {
   count = var.gke_fleet_host_project_id == "" ? 1 : 0
 
+  labels  = var.labels
   name    = "istio-gateway-mci"
   project = var.project
 }

--- a/tests/fixtures/primary/main.tf
+++ b/tests/fixtures/primary/main.tf
@@ -29,5 +29,12 @@ module "test" {
     }
   }
 
+  labels = {
+    cost-center = "x000"
+    env         = "mock"
+    team        = "mock"
+    repository  = "mock"
+  }
+
   project = var.project
 }

--- a/tests/fixtures/primary/regional/main.tf
+++ b/tests/fixtures/primary/regional/main.tf
@@ -86,6 +86,13 @@ module "test" {
     }
   }
 
+  labels = {
+    cost-center = "x000"
+    env         = "mock"
+    team        = "mock"
+    repository  = "mock"
+  }
+
   project = var.project
   region  = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "istio_gateway_dns" {
   default = {}
 }
 
+variable "labels" {
+  description = "A map of key/value pairs to assign to the resources being created"
+  type        = map(string)
+  default     = {}
+}
+
 variable "project" {
   description = "The ID of the project in which the resource belongs"
   type        = string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `labels` variable for resource labeling, enhancing organization and management capabilities.
	- Added `labels` attribute to the `google_compute_global_address` resource for better resource identification.
	- Included new `labels` blocks in module configurations for improved resource categorization.

- **Documentation**
	- Updated `README.md` to include detailed information about the new `labels` variable and its usage.
	- Enhanced clarity around resource configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->