### PR TITLE
Use default-deny patterns

### DIFF
--- a/regional/README.md
+++ b/regional/README.md
@@ -11,9 +11,9 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.0.1 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.15.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.40.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.14.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.31.0 |
 
 ## Modules
 

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.31.0 |
 
 ## Modules
 
@@ -20,6 +20,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [kubernetes_manifest.gke_info_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_cluster_services_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_kubernetes_default_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |

--- a/regional/manifests/main.tf
+++ b/regional/manifests/main.tf
@@ -152,6 +152,8 @@ resource "kubernetes_manifest" "istio_authorization_policy" {
     }
 
     # It's recommended to define authorization policies following the default-deny pattern to enhance your cluster’s security posture.
+    # The spec field of the policy has the empty value {}. That value means that no traffic is permitted, effectively denying all requests.
+
     spec = {}
   }
 }


### PR DESCRIPTION
Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new resource for managing Istio authorization policies within Kubernetes manifests.
- **Documentation**
	- Updated version numbers for Google, Helm, and Kubernetes providers in the README files.
	- Enhanced documentation by adding a new resource entry for `kubernetes_manifest.istio_authorization_policy`.
- **Refactor**
	- Improved formatting of manifest definitions for better readability and standard compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->