### PR TITLE
Rename gke-info-go to istio-test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.2
+    rev: v1.97.0
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.343
+    rev: 3.2.353
     hooks:
       - id: checkov
         verbose: true

--- a/regional/helm/istiod.yml
+++ b/regional/helm/istiod.yml
@@ -1,5 +1,7 @@
 global:
   caAddress: cert-manager-istio-csr.cert-manager.svc:443
+  certSigners:
+    - clusterissuers.cert-manager.io/istio-ca
   meshID: default
   network: standard-shared
 

--- a/regional/helm/istiod.yml
+++ b/regional/helm/istiod.yml
@@ -1,7 +1,5 @@
 global:
   caAddress: cert-manager-istio-csr.cert-manager.svc:443
-  certSigners:
-    - clusterissuers.cert-manager.io/istio-ca
   meshID: default
   network: standard-shared
 

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -21,8 +21,10 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [kubernetes_manifest.istio_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_cluster_services_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_gateway_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_kubernetes_default_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_peer_authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_test_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -21,24 +21,24 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [kubernetes_manifest.gke_info_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_cluster_services_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_gateway_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_kubernetes_default_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_peer_authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.istio_test_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_common_gke_info_virtual_services"></a> [common\_gke\_info\_virtual\_services](#input\_common\_gke\_info\_virtual\_services) | The map of Istio VirtualServices to create for GKE Info, that are common among all regions | <pre>map(object({<br/>    destination_host = string<br/>    host             = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_common_istio_test_virtual_services"></a> [common\_istio\_test\_virtual\_services](#input\_common\_istio\_test\_virtual\_services) | The map of Istio VirtualServices to create for Istio testing, that are common among all regions | <pre>map(object({<br/>    destination_host = string<br/>    host             = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_common_virtual_services"></a> [common\_virtual\_services](#input\_common\_virtual\_services) | The map of Istio VirtualServices to create, that are common among all regions | <pre>map(object({<br/>    destination_host = string<br/>    destination_port = optional(number, 8080)<br/>    host             = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_failover_from_region"></a> [failover\_from\_region](#input\_failover\_from\_region) | The region to fail over from | `string` | `""` | no |
 | <a name="input_failover_to_region"></a> [failover\_to\_region](#input\_failover\_to\_region) | The region to fail over to | `string` | `""` | no |
-| <a name="input_gke_info_virtual_services"></a> [gke\_info\_virtual\_services](#input\_gke\_info\_virtual\_services) | The map of Istio VirtualServices to create for GKE Info | <pre>map(object({<br/>    destination_host = string<br/>    host             = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_istio_test_virtual_services"></a> [istio\_test\_virtual\_services](#input\_istio\_test\_virtual\_services) | The map of Istio VirtualServices to create for Istio testing | <pre>map(object({<br/>    destination_host = string<br/>    host             = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_virtual_services"></a> [virtual\_services](#input\_virtual\_services) | The map of Istio VirtualServices to create, that are unique to a region | <pre>map(object({<br/>    destination_host = string<br/>    destination_port = optional(number, 8080)<br/>    host             = string<br/>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -21,10 +21,8 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [kubernetes_manifest.istio_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_cluster_services_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-| [kubernetes_manifest.istio_gateway_authorization_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_kubernetes_default_destination_rule](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_peer_authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.istio_test_istio_virtual_services](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |

--- a/regional/manifests/main.tf
+++ b/regional/manifests/main.tf
@@ -225,8 +225,8 @@ resource "kubernetes_manifest" "istio_virtual_services" {
   }
 }
 
-resource "kubernetes_manifest" "gke_info_istio_virtual_services" {
-  for_each = merge(var.gke_info_virtual_services, var.common_gke_info_virtual_services)
+resource "kubernetes_manifest" "istio_test_istio_virtual_services" {
+  for_each = merge(var.istio_test_virtual_services, var.istio_test_virtual_services)
 
   manifest = {
     apiVersion = "networking.istio.io/v1beta1"
@@ -250,7 +250,7 @@ resource "kubernetes_manifest" "gke_info_istio_virtual_services" {
           match = [
             {
               uri = {
-                prefix = "/gke-info-go"
+                prefix = "/istio-test"
               }
             }
           ]

--- a/regional/manifests/main.tf
+++ b/regional/manifests/main.tf
@@ -118,38 +118,38 @@ resource "kubernetes_manifest" "istio_gateway" {
   }
 }
 
-# resource "kubernetes_manifest" "istio_gateway_authorization_policy" {
-#   manifest = {
-#     apiVersion = "security.istio.io/v1"
-#     kind       = "AuthorizationPolicy"
+resource "kubernetes_manifest" "istio_gateway_authorization_policy" {
+  manifest = {
+    apiVersion = "security.istio.io/v1"
+    kind       = "AuthorizationPolicy"
 
-#     metadata = {
-#       name      = "allow-all-gateway"
-#       namespace = "istio-ingress"
-#     }
+    metadata = {
+      name      = "allow-all-gateway"
+      namespace = "istio-ingress"
+    }
 
-#     spec = {
-#       action = "ALLOW"
-#       rules = [
-#         {
-#           to = [
-#             {
-#               operation = {
-#                 methods = ["*"]
-#               }
-#             }
-#           ]
-#         }
-#       ]
+    spec = {
+      action = "ALLOW"
+      rules = [
+        {
+          to = [
+            {
+              operation = {
+                methods = ["*"]
+              }
+            }
+          ]
+        }
+      ]
 
-#       selector = {
-#         matchLabels = {
-#           istio = "gateway"
-#         }
-#       }
-#     }
-#   }
-# }
+      selector = {
+        matchLabels = {
+          istio = "gateway"
+        }
+      }
+    }
+  }
+}
 
 resource "kubernetes_manifest" "istio_peer_authentication" {
   manifest = {
@@ -169,22 +169,22 @@ resource "kubernetes_manifest" "istio_peer_authentication" {
   }
 }
 
-# resource "kubernetes_manifest" "istio_authorization_policy" {
-#   manifest = {
-#     apiVersion = "security.istio.io/v1"
-#     kind       = "AuthorizationPolicy"
+resource "kubernetes_manifest" "istio_authorization_policy" {
+  manifest = {
+    apiVersion = "security.istio.io/v1"
+    kind       = "AuthorizationPolicy"
 
-#     metadata = {
-#       name      = "deny-all"
-#       namespace = "istio-system"
-#     }
+    metadata = {
+      name      = "deny-all"
+      namespace = "istio-system"
+    }
 
-#     # It's recommended to define authorization policies following the default-deny pattern to enhance your cluster’s security posture.
-#     # The spec field of the policy has the empty value {}. That value means that no traffic is permitted, effectively denying all requests.
+    # It's recommended to define authorization policies following the default-deny pattern to enhance your cluster’s security posture.
+    # The spec field of the policy has the empty value {}. That value means that no traffic is permitted, effectively denying all requests.
 
-#     spec = {}
-#   }
-# }
+    spec = {}
+  }
+}
 
 resource "kubernetes_manifest" "istio_virtual_services" {
   for_each = merge(var.virtual_services, var.common_virtual_services)

--- a/regional/manifests/main.tf
+++ b/regional/manifests/main.tf
@@ -118,38 +118,38 @@ resource "kubernetes_manifest" "istio_gateway" {
   }
 }
 
-resource "kubernetes_manifest" "istio_gateway_authorization_policy" {
-  manifest = {
-    apiVersion = "security.istio.io/v1"
-    kind       = "AuthorizationPolicy"
+# resource "kubernetes_manifest" "istio_gateway_authorization_policy" {
+#   manifest = {
+#     apiVersion = "security.istio.io/v1"
+#     kind       = "AuthorizationPolicy"
 
-    metadata = {
-      name      = "allow-all-gateway"
-      namespace = "istio-ingress"
-    }
+#     metadata = {
+#       name      = "allow-all-gateway"
+#       namespace = "istio-ingress"
+#     }
 
-    spec = {
-      action = "ALLOW"
-      rules = [
-        {
-          to = [
-            {
-              operation = {
-                methods = ["*"]
-              }
-            }
-          ]
-        }
-      ]
+#     spec = {
+#       action = "ALLOW"
+#       rules = [
+#         {
+#           to = [
+#             {
+#               operation = {
+#                 methods = ["*"]
+#               }
+#             }
+#           ]
+#         }
+#       ]
 
-      selector = {
-        matchLabels = {
-          istio = "gateway"
-        }
-      }
-    }
-  }
-}
+#       selector = {
+#         matchLabels = {
+#           istio = "gateway"
+#         }
+#       }
+#     }
+#   }
+# }
 
 resource "kubernetes_manifest" "istio_peer_authentication" {
   manifest = {
@@ -169,22 +169,22 @@ resource "kubernetes_manifest" "istio_peer_authentication" {
   }
 }
 
-resource "kubernetes_manifest" "istio_authorization_policy" {
-  manifest = {
-    apiVersion = "security.istio.io/v1"
-    kind       = "AuthorizationPolicy"
+# resource "kubernetes_manifest" "istio_authorization_policy" {
+#   manifest = {
+#     apiVersion = "security.istio.io/v1"
+#     kind       = "AuthorizationPolicy"
 
-    metadata = {
-      name      = "deny-all"
-      namespace = "istio-system"
-    }
+#     metadata = {
+#       name      = "deny-all"
+#       namespace = "istio-system"
+#     }
 
-    # It's recommended to define authorization policies following the default-deny pattern to enhance your cluster’s security posture.
-    # The spec field of the policy has the empty value {}. That value means that no traffic is permitted, effectively denying all requests.
+#     # It's recommended to define authorization policies following the default-deny pattern to enhance your cluster’s security posture.
+#     # The spec field of the policy has the empty value {}. That value means that no traffic is permitted, effectively denying all requests.
 
-    spec = {}
-  }
-}
+#     spec = {}
+#   }
+# }
 
 resource "kubernetes_manifest" "istio_virtual_services" {
   for_each = merge(var.virtual_services, var.common_virtual_services)

--- a/regional/manifests/main.tf
+++ b/regional/manifests/main.tf
@@ -226,7 +226,7 @@ resource "kubernetes_manifest" "istio_virtual_services" {
 }
 
 resource "kubernetes_manifest" "istio_test_istio_virtual_services" {
-  for_each = merge(var.istio_test_virtual_services, var.istio_test_virtual_services)
+  for_each = merge(var.istio_test_virtual_services, var.common_istio_test_virtual_services)
 
   manifest = {
     apiVersion = "networking.istio.io/v1beta1"

--- a/regional/manifests/variables.tf
+++ b/regional/manifests/variables.tf
@@ -1,8 +1,8 @@
 # Input Variables
 # https://www.terraform.io/language/values/variables
 
-variable "common_gke_info_virtual_services" {
-  description = "The map of Istio VirtualServices to create for GKE Info, that are common among all regions"
+variable "common_istio_test_virtual_services" {
+  description = "The map of Istio VirtualServices to create for Istio testing, that are common among all regions"
   type = map(object({
     destination_host = string
     host             = string
@@ -30,8 +30,8 @@ variable "failover_to_region" {
   default     = ""
 }
 
-variable "gke_info_virtual_services" {
-  description = "The map of Istio VirtualServices to create for GKE Info"
+variable "istio_test_virtual_services" {
+  description = "The map of Istio VirtualServices to create for Istio testing"
   type = map(object({
     destination_host = string
     host             = string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated pre-commit tool versions for `antonbabenko/pre-commit-terraform` and `bridgecrewio/checkov`

- **Documentation**
	- Updated Terraform documentation for Istio testing virtual services
	- Renamed and clarified input variable descriptions related to Istio testing

- **Refactor**
	- Renamed Kubernetes manifest resources and variables from GKE Info to Istio testing
	- Modified virtual service routing path from "/gke-info-go" to "/istio-test"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->