### PR TITLE
Update Istio to 1.25.2 , provider versions and pre-commit hooks in configuration files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.3
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.368
+    rev: 3.2.408
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 6.14.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.32.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 6.32.0 |
 
 ### Modules
 

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,9 +11,9 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.32.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.36.0 |
 
 ## Modules
 
@@ -56,7 +56,7 @@ No requirements.
 | <a name="input_gateway_mci_global_address"></a> [gateway\_mci\_global\_address](#input\_gateway\_mci\_global\_address) | The IP address for the Istio Gateway multi-cluster ingress | `string` | `""` | no |
 | <a name="input_gateway_memory_limits"></a> [gateway\_memory\_limits](#input\_gateway\_memory\_limits) | The memory limit for the Istio gateway | `string` | `"64Mi"` | no |
 | <a name="input_gateway_memory_requests"></a> [gateway\_memory\_requests](#input\_gateway\_memory\_requests) | The memory request for the Istio gateway | `string` | `"32Mi"` | no |
-| <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | The version to install, this is used for the chart as well as the image tag | `string` | `"1.24.2"` | no |
+| <a name="input_istio_version"></a> [istio\_version](#input\_istio\_version) | The version to install, this is used for the chart as well as the image tag | `string` | `"1.25.2"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | A map of key/value pairs to assign to the resources being created | `map(string)` | `{}` | no |
 | <a name="input_multi_cluster_service_clusters"></a> [multi\_cluster\_service\_clusters](#input\_multi\_cluster\_service\_clusters) | List of clusters to be included in the MultiClusterService | <pre>list(object({<br/>    link = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_node_location"></a> [node\_location](#input\_node\_location) | The zone in which the cluster's nodes should be located. If not specified, the cluster's nodes are located across zones in the region | `string` | `null` | no |

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.36.0 |
 
 ## Modules
 

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -72,7 +72,7 @@ variable "gateway_memory_requests" {
 variable "istio_version" {
   description = "The version to install, this is used for the chart as well as the image tag"
   type        = string
-  default     = "1.24.2"
+  default     = "1.25.2"
 }
 
 variable "labels" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit tool and Checkov versions for improved checks.
  - Upgraded provider versions for Google, Google Beta, and Kubernetes in documentation.
- **Documentation**
  - Refreshed Terraform documentation to reflect updated provider versions.
  - Updated default Istio version in module documentation.
- **New Features**
  - Changed the default Istio version to 1.25.2 for regional modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->